### PR TITLE
hotfix: install Heroku CLI on deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up heroku cli
+        run: curl https://cli-assets.heroku.com/install.sh | sh
       
       - name: Setup Docker context
         run: |


### PR DESCRIPTION
self hosted runnerにはheroku cliがない