### PR TITLE
chore: remove workarounds for setup-buildx-action and actions/runner@v2.285.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,18 +17,8 @@ jobs:
       
       - name: Setup Docker context
         run: |
-          echo $HOME
           docker context create another-context
           docker context use another-context
-
-      # https://github.com/docker/setup-buildx-action/issues/117 の回避
-      - name: Set up buildx
-        run: |
-          mkdir -p $HOME/.docker/cli-plugins
-          curl -L -o $HOME/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/$BUILDX_VERSION/buildx-$BUILDX_VERSION.linux-amd64
-          chmod a+x ~/.docker/cli-plugins/docker-buildx
-        env:
-          BUILDX_VERSION: v0.7.1
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v1
@@ -37,8 +27,6 @@ jobs:
           config-inline: |
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
-        env:
-          DOCKER_CONFIG: /home/runner/.docker
 
       - name: Login to docker registry
         uses: docker/login-action@v1
@@ -79,6 +67,7 @@ jobs:
           cache-to: type=registry,ref=registry.misw.jp/birdol/web:cache,mode=max
 
       - name: Release
+        if: ${{ github.event_name == 'push' && github.ref == 'ref/heads/main' }}
         run: |
           heroku container:login
           heroku container:release -a birdol web


### PR DESCRIPTION
[actions/runner@v2.285.1で問題が修正された](https://github.com/actions/runner/releases/tag/v2.285.1)